### PR TITLE
added ExecuteCommand and RecordEvent  to Engine

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -279,3 +279,18 @@ func (e *Engine) handle(
 
 	return envs, err
 }
+
+// ExecuteCommand enqueues a command for execution. It panics if command is not
+// routed to any handlers.
+func (e *Engine) ExecuteCommand(ctx context.Context, m dogma.Message) error {
+	t := message.TypeOf(m)
+	e.roles[t].MustBe(message.CommandRole)
+
+	return e.Dispatch(ctx, m)
+}
+
+// RecordEvent records the occurrence of an event. It is not an error to attempt
+// recording of the event that is not routed to any handlers.
+func (e *Engine) RecordEvent(ctx context.Context, m dogma.Message) error {
+	return e.Dispatch(ctx, m)
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -280,8 +280,8 @@ func (e *Engine) handle(
 	return envs, err
 }
 
-// ExecuteCommand enqueues a command for execution. It panics if command is not
-// routed to any handlers.
+// ExecuteCommand enqueues a command for execution. It panics if the command is
+// not routed to any handlers.
 func (e *Engine) ExecuteCommand(ctx context.Context, m dogma.Message) error {
 	t := message.TypeOf(m)
 	e.roles[t].MustBe(message.CommandRole)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -289,8 +289,8 @@ func (e *Engine) ExecuteCommand(ctx context.Context, m dogma.Message) error {
 	return e.Dispatch(ctx, m)
 }
 
-// RecordEvent records the occurrence of an event. It is not an error to attempt
-// recording an event that is not routed to any handlers.
+// RecordEvent records the occurrence of an event. It is not an error to record
+// an event that is not routed to any handlers.
 func (e *Engine) RecordEvent(ctx context.Context, m dogma.Message) error {
 	return e.Dispatch(ctx, m)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -290,7 +290,7 @@ func (e *Engine) ExecuteCommand(ctx context.Context, m dogma.Message) error {
 }
 
 // RecordEvent records the occurrence of an event. It is not an error to attempt
-// recording of the event that is not routed to any handlers.
+// recording an event that is not routed to any handlers.
 func (e *Engine) RecordEvent(ctx context.Context, m dogma.Message) error {
 	return e.Dispatch(ctx, m)
 }


### PR DESCRIPTION
PR to add two methods (ExecuteCommand and RecordEvent) to the dogma test engine to implement the `dogma.CommandExecutor` and `dogma.EventRecorder` interfaces.